### PR TITLE
Add a configuration parameter to download dart-sass from another location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ plugins {
 
 #### Download
 
-By default, the plugin downloads [Dart-Sass](https://github.com/sass/dart-sass) (Sass official implementation).
+By default, the plugin downloads [Dart-Sass](https://github.com/sass/dart-sass) (Sass official implementation). You can specify another download location
+through `downloadBaseUrl` attribute.
 
 If need be, you can configure the download:
 
@@ -28,6 +29,7 @@ If need be, you can configure the download:
 sass {
     download {
         version = "1.13.4" // Default: "0.14.3".
+        downloadBaseUrl = "http://mirror.example.com" // Default: "https://github.com/sass/dart-sass/releases/download".
         outputDir = file("wherever/I/want") // Default: "$gradleUserHome/sass".
     }
 }

--- a/src/main/kotlin/com/github/salomonbrys/gradle/sass/SassExtension.kt
+++ b/src/main/kotlin/com/github/salomonbrys/gradle/sass/SassExtension.kt
@@ -8,6 +8,8 @@ import java.io.File
 
 class SassExtension(project: Project) {
 
+    val DEFAULT_DOWNLOAD_URL = "https://github.com/sass/dart-sass/releases/download"
+
     val DEFAULT_VERSION = "1.14.3"
 
     val DEFAULT_SASS_EXE = if (OperatingSystem.current().isWindows) "sass.bat" else "sass"
@@ -15,23 +17,23 @@ class SassExtension(project: Project) {
     val DEFAULT_SASS_DIR = File("${project.gradle.gradleUserHomeDir}/sass")
 
     sealed class Exe {
-        data class Download(var version: String, var outputDir: File) : Exe()
+        data class Download(var downloadBaseUrl: String, var version: String, var outputDir: File) : Exe()
         data class Local(var path: String) : Exe()
     }
 
-    var exe: Exe = Exe.Download(DEFAULT_VERSION, DEFAULT_SASS_DIR)
+    var exe: Exe = Exe.Download(DEFAULT_DOWNLOAD_URL, DEFAULT_VERSION, DEFAULT_SASS_DIR)
 
     @JvmOverloads
     fun download(action: Action<Exe.Download> = Action {}) {
-        exe = Exe.Download(DEFAULT_VERSION, DEFAULT_SASS_DIR).apply(action)
+        exe = Exe.Download(DEFAULT_DOWNLOAD_URL, DEFAULT_VERSION, DEFAULT_SASS_DIR).apply(action)
     }
 
     fun download(action: Exe.Download.() -> Unit) {
-        exe = Exe.Download(DEFAULT_VERSION, DEFAULT_SASS_DIR).apply(action)
+        exe = Exe.Download(DEFAULT_DOWNLOAD_URL, DEFAULT_VERSION, DEFAULT_SASS_DIR).apply(action)
     }
 
     fun download(action: Closure<*>) {
-        exe = Exe.Download(DEFAULT_VERSION, DEFAULT_SASS_DIR).apply(action)
+        exe = Exe.Download(DEFAULT_DOWNLOAD_URL, DEFAULT_VERSION, DEFAULT_SASS_DIR).apply(action)
     }
 
     @JvmOverloads

--- a/src/main/kotlin/com/github/salomonbrys/gradle/sass/SassPlugin.kt
+++ b/src/main/kotlin/com/github/salomonbrys/gradle/sass/SassPlugin.kt
@@ -49,7 +49,7 @@ class SassPlugin : Plugin<Project> {
                     val archive = "dart-sass-${exe.version}-$os-$arch.$ext"
                     val output = File("${gradle.gradleUserHomeDir}/sass/archive/$archive")
                     onlyIf { !output.exists() }
-                    src("https://github.com/sass/dart-sass/releases/download/${exe.version}/$archive")
+                    src("${exe.downloadBaseUrl}/${exe.version}/$archive")
                     dest(output)
                     tempAndMove(true)
                 }


### PR DESCRIPTION
This new parameter is useful in an enterprise environment when you have to use a mirror to fetch binaries.
An improvement could be to be able to tune also the filename pattern, but I didn't need this part in my use case.